### PR TITLE
Find Eigen in the correct directory

### DIFF
--- a/cmake_modules/FindEigen3.cmake
+++ b/cmake_modules/FindEigen3.cmake
@@ -63,7 +63,7 @@ else (EIGEN3_INCLUDE_DIR)
 
   find_path(EIGEN3_INCLUDE_DIR NAMES signature_of_eigen3_matrix_library
       PATHS
-      ${CMAKE_INSTALL_PREFIX}/include
+      /usr/local/include
       ${KDE4_INCLUDE_DIR}
       PATH_SUFFIXES eigen3 eigen
     )


### PR DESCRIPTION
The install prefix is intended to be where the package will place files, not where they are looked for. This changes the find path for eigen to its default. When building Sophus, `CMAKE_PREFIX_PATH` should be specified on the command line. find_path already automatically adds `/include` to `CMAKE_PREFIX_PATH`, so putting eigen into a directory hierarchy with `/include` at the root will still be okay.