### PR TITLE
update FindEigen3.cmake, look for environment variable `EIGEN3_INCLUDE_DIR`.

### DIFF
--- a/cmake_modules/FindEigen3.cmake
+++ b/cmake_modules/FindEigen3.cmake
@@ -67,6 +67,7 @@ else (EIGEN3_INCLUDE_DIR)
       /opt/local/include
       ${CMAKE_INSTALL_PREFIX}/include
       ${KDE4_INCLUDE_DIR}
+	  $ENV{EIGEN3_INCLUDE_DIR}
       PATH_SUFFIXES eigen3 eigen
     )
 


### PR DESCRIPTION
To improve the `FindEigen3.cmake` file, I am suggesting to add a search for the environment variable `EIGEN3_INCLUDE_DIR`.

In that way, it is easy for a user to use a non-default location for Eigen.
